### PR TITLE
Fix for Indicator randomly turning off

### DIFF
--- a/Firmware/WellSystemMonitor/src/WellSystemMonitor.ino
+++ b/Firmware/WellSystemMonitor/src/WellSystemMonitor.ino
@@ -24,6 +24,8 @@
 
     author: Bob Glicksman, Jim Schrempp; 06/25/2018
     version 1.1: corrected bug that turned LED Indicator off sporatically; Bob Glicksman 12/19/18
+    version 1.2: made change to enable the system thread so that firmware can detect disconnects 
+    	from the Particle cloud; Bob Glicksman 12/20/18
 
     (c) 2017, 2018 Bob Glicksman and Jim Schrempp, Team Practical Projects
 
@@ -112,6 +114,8 @@ void reportDeviceRestart()
 boolean LEDPinState = false;   // D7 LED is used for indicating DHT measurements
 String mg_particleSensorReport = "";
 String mg_particleDHTReport = "";
+
+SYSTEM_THREAD(ENABLED); // run threaded operation so firmware can detect and process disconnects from the Particle cloud
 
 // setup()
 void setup() {

--- a/Firmware/WellSystemMonitor/src/WellSystemMonitor.ino
+++ b/Firmware/WellSystemMonitor/src/WellSystemMonitor.ino
@@ -23,6 +23,7 @@
         storage.
 
     author: Bob Glicksman, Jim Schrempp; 06/25/2018
+    version 1.1: corrected bug that turned LED Indicator off sporatically; Bob Glicksman 12/19/18
 
     (c) 2017, 2018 Bob Glicksman and Jim Schrempp, Team Practical Projects
 
@@ -257,6 +258,8 @@ void loop() {
 
     if (not Particle.connected()) {
         nbFlashIndicator(true);
+    } else {
+        digitalWrite(INDICATOR_PIN, mg_pushbutton.value);  //if the push button is depressed, turn off indicator
     }
 
 } // end of loop()


### PR DESCRIPTION
I found the bug and this firmware version (1.1) fixes it.  The bug was
in loop() circa line 259.  There is a test for not being connected to
the Particle cloud and if it is true (not connected), the indicator is
flashed.  This test can end anytime the device reconnects to the cloud
and can leave the indicator in the off state because there is no code to
retest the pushbutton state until the latter changes.  I added an "else"
in line 261 which tests the current status of the pushbutton and sets
the indicator accordingly.